### PR TITLE
Fixes for jq and flip template variables and various other minor fixes

### DIFF
--- a/psconfig/perfsonar-psconfig/psconfig/lib/shared/client/psconfig/groups/base_p2p_group.py
+++ b/psconfig/perfsonar-psconfig/psconfig/lib/shared/client/psconfig/groups/base_p2p_group.py
@@ -46,7 +46,7 @@ class BaseP2PGroup(BaseGroup):
         excludes = self.excludes()
         if len(excludes) > 0:
             #init _exclude_checksum_map if needed
-            if not self._exclude_checksum_map():
+            if not self._exclude_checksum_map:
                 tmp_map = {}
                 for excl_pair in excludes:
                     local_checksum = excl_pair.local_address().checksum()

--- a/psconfig/perfsonar-psconfig/psconfig/lib/shared/utilities/jq.py
+++ b/psconfig/perfsonar-psconfig/psconfig/lib/shared/utilities/jq.py
@@ -8,7 +8,7 @@ def jq(jq, json_obj, formatting_params=None, timeout=None):
 
     #initialize formatting params
     try:
-        value = pyjq.all(jq, json_obj)
+        value = pyjq.one(jq, json_obj)
         return value
     except Exception as e:
         raise Exception('jq error: {}'.format(e))


### PR DESCRIPTION
- Fixes jq template variable. We want it to always return 1 result and forces it to be a string. 
- Fixes flip variable so can properly be parsed as json
- Fixes various places where () were missing
- Fixes init call where kwargs were not being used to assign to class vars
- Fixed issue where exception was thrown when address was a hostname