### PR TITLE
Fixes-issue-34

### DIFF
--- a/psconfig/perfsonar-psconfig/psconfig/client/psconfig/base_connect.py
+++ b/psconfig/perfsonar-psconfig/psconfig/client/psconfig/base_connect.py
@@ -8,32 +8,7 @@ import os
 import json
 from urllib.parse import urlparse
 import logging
-
-
-def json_decomment(json_obj, prefix='#', null=False):
-    """
-    Remove any JSON object emember whose name begins with 'prefix'
-    (default '#') and return the result.  If 'null' is True, replace
-    the prefixed items with a null value instead of deleting them.
-    """
-    if type(json_obj) is dict:
-        result = {}
-        for item in json_obj.keys():
-            if item.startswith(prefix):
-                if null:
-                    result[item] = None
-                else:
-                    next
-            else:
-                result[item] = json_decomment(json_obj[item], prefix=prefix, null=null)
-        return result
-    elif type(json_obj) is list:
-        result = []
-        for item in json_obj:
-            result.append(json_decomment(item, prefix=prefix, null=null))
-        return result
-    else:
-        return json_obj
+from pscheduler.psjson import json_decomment
 
 
 class BaseConnect(object):

--- a/psconfig/perfsonar-psconfig/psconfig/client/psconfig/base_connect.py
+++ b/psconfig/perfsonar-psconfig/psconfig/client/psconfig/base_connect.py
@@ -9,6 +9,33 @@ import json
 from urllib.parse import urlparse
 import logging
 
+
+def json_decomment(json_obj, prefix='#', null=False):
+    """
+    Remove any JSON object emember whose name begins with 'prefix'
+    (default '#') and return the result.  If 'null' is True, replace
+    the prefixed items with a null value instead of deleting them.
+    """
+    if type(json_obj) is dict:
+        result = {}
+        for item in json_obj.keys():
+            if item.startswith(prefix):
+                if null:
+                    result[item] = None
+                else:
+                    next
+            else:
+                result[item] = json_decomment(json_obj[item], prefix=prefix, null=null)
+        return result
+    elif type(json_obj) is list:
+        result = []
+        for item in json_obj:
+            result.append(json_decomment(item, prefix=prefix, null=null))
+        return result
+    else:
+        return json_obj
+
+
 class BaseConnect(object):
 
     def __init__(self, **kwargs):
@@ -133,6 +160,8 @@ class BaseConnect(object):
 
         try:
             json_obj = json.loads(raw_config)
+            # remove comments
+            json_obj = json_decomment(json_obj)
         except Exception as e:
             json_error = e
 

--- a/psconfig/perfsonar-psconfig/unibuild-packaging/deb/control
+++ b/psconfig/perfsonar-psconfig/unibuild-packaging/deb/control
@@ -15,7 +15,8 @@ Architecture: all
 Depends: python3, ${misc:Depends},
  python3-requests, python3-jsonschema (>= 3.0.1~0), python3-tqdm,
  python3-isodate (>= 0.5.0), python3-dnspython, python3-pyjq,
- python3-netifaces, python3-dateutil, python3-file-read-backwards
+ python3-netifaces, python3-dateutil, python3-file-read-backwards,
+ python3-pscheduler
 Description: pSConfig library
  Utility functions for pSConfig
 

--- a/psconfig/perfsonar-psconfig/unibuild-packaging/rpm/perfsonar-psconfig.spec
+++ b/psconfig/perfsonar-psconfig/unibuild-packaging/rpm/perfsonar-psconfig.spec
@@ -63,6 +63,7 @@ Requires:       %{_python}-isodate
 Requires:       %{_python}-dns
 Requires:       %{_python}-tqdm
 Requires:       %{_python}-file-read-backwards
+Requires:       %{_python}-pscheduler
 BuildRequires:  %{_python}
 BuildRequires:  %{_python}-setuptools
 BuildArch:		noarch


### PR DESCRIPTION
pScheduler style 'comments'  in JSON files.
JSON "keys" that start with \# will be considered "comments" and ignored when parsing the config file. 

example ```/etc/perfsonar/psconfig/pscheduler-agent.json```:
```
{
	'remotes': [],
	'#comment': "example"
}
```
previously gave an error:
```
...Error: Additional properties are not allowed ('#comment' were unexpected)
```
now - no errors.


code from [pScheduler](https://github.com/perfsonar/pscheduler/blob/47078cbaac5212330eeeaa9c51f3eac23a0ee883/python-pscheduler/pscheduler/pscheduler/psjson.py#L13)