### PR TITLE
Fixes wrong units for RTT test in Endpoint Pair Explorer

### DIFF
--- a/psconfig/perfsonar-psconfig/templates/endpoints.json.j2
+++ b/psconfig/perfsonar-psconfig/templates/endpoints.json.j2
@@ -2588,7 +2588,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -2917,7 +2917,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },


### PR DESCRIPTION
This PR is related to https://github.com/perfsonar/grafana/issues/55 and fixes it in psconfig template